### PR TITLE
233 add server sharing capabilities

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -64,7 +64,7 @@ class SpacesController < ApplicationController
   private
 
   def belongs_to_user
-    !current_user.nil? && (@space.creator_id == current_user.id)
+    !current_user.nil? && (@space.creator_id == current_user.id || @space.owned_by?(current_user))
   end
 
   def check_authorization

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -8,11 +8,10 @@ class SpacesController < ApplicationController
   def index
     if params['user_id']
       @user = User.find(params['user_id'])
-      @spaces = @user.spaces.visible_by(current_user) # TODO(matthew): Fix
+      @spaces = @user.spaces.visible_by(current_user)
     else
       @spaces = Space.visible_by(current_user).first(10)
     end
-    #render json: @spaces.as_json(only: [:id, :name, :description, :updated_at, :user_id])
     render json: SpacesRepresenter.new(@spaces).to_json
   end
 
@@ -35,11 +34,11 @@ class SpacesController < ApplicationController
     @space.creator = current_user
 
     if !space_params.has_key? :is_private
-      @space.is_private = @space.user.prefers_private?
+      @space.is_private = @space.creator.prefers_private?
     end
 
     if @space.save
-      render json: @space
+      render json: SpaceRepresenter.new(@space).to_json
     else
       render json: @space.errors, status: :unprocessable_entity
     end
@@ -49,7 +48,7 @@ class SpacesController < ApplicationController
   # PATCH/PUT /spaces/1.json
   def update
     if @space.update(space_params)
-      render json: @space, status: :ok
+      render json: SpaceRepresenter.new(@space).to_json, status: :ok
     else
       render json: @space.errors, status: :unprocessable_entity
     end
@@ -92,6 +91,13 @@ class SpacesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def space_params
-    params.require(:space).permit(:name, :description, :user_id, :is_private, graph: graph_structure)
+    filtered_params = params.require(:space).permit(:name, :description, :user_id, :is_private, graph: graph_structure)
+
+    if filtered_params.has_key?(:space) && filtered_params[:space].has_key?(:user_id)
+      filtered_params[:space][:creator_id] = filtered_params[:space][:user_id]
+      filtered_params[:space].delete(:user_id)
+    end
+
+    filtered_params
   end
 end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -8,7 +8,7 @@ class SpacesController < ApplicationController
   def index
     if params['user_id']
       @user = User.find(params['user_id'])
-      @spaces = @user.spaces.visible_by(current_user)
+      @spaces = @user.spaces.visible_by(current_user) # TODO(matthew): Fix
     else
       @spaces = Space.visible_by(current_user).first(10)
     end
@@ -32,7 +32,7 @@ class SpacesController < ApplicationController
   # POST /spaces.json
   def create
     @space = Space.new(space_params)
-    @space.user = current_user
+    @space.creator = current_user
 
     if !space_params.has_key? :is_private
       @space.is_private = @space.user.prefers_private?
@@ -65,7 +65,7 @@ class SpacesController < ApplicationController
   private
 
   def belongs_to_user
-    !current_user.nil? && (@space.user_id == current_user.id)
+    !current_user.nil? && (@space.creator_id == current_user.id)
   end
 
   def check_authorization

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -8,7 +8,7 @@ class SpacesController < ApplicationController
   def index
     if params['user_id']
       @user = User.find(params['user_id'])
-      @spaces = @user.spaces.visible_by(current_user)
+      @spaces = @user.spaces_visible_by(current_user) 
     else
       @spaces = Space.visible_by(current_user).first(10)
     end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -8,7 +8,7 @@ class SpacesController < ApplicationController
   def index
     if params['user_id']
       @user = User.find(params['user_id'])
-      @spaces = @user.spaces_visible_by(current_user) 
+      @spaces = @user.spaces_visible_by(current_user)
     else
       @spaces = Space.visible_by(current_user).first(10)
     end
@@ -91,13 +91,6 @@ class SpacesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def space_params
-    filtered_params = params.require(:space).permit(:name, :description, :user_id, :is_private, graph: graph_structure)
-
-    if filtered_params.has_key?(:space) && filtered_params[:space].has_key?(:user_id)
-      filtered_params[:space][:creator_id] = filtered_params[:space][:user_id]
-      filtered_params[:space].delete(:user_id)
-    end
-
-    filtered_params
+    params.require(:space).permit(:name, :description, :is_private, graph: graph_structure)
   end
 end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -2,7 +2,7 @@ class Space < ActiveRecord::Base
   include AlgoliaSearch
   include FakeNameDetector
 
-  has_many :permissions, class_name: "UserSpacePermission"
+  has_many :permissions, class_name: "UserSpacePermission", dependent: :destroy
   has_many :users, through: :permissions
   has_many :ownerships, -> { own }, class_name: "UserSpacePermission"
   has_many :owners, through: :ownerships, source: :user

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -19,9 +19,9 @@ class Space < ActiveRecord::Base
   validates :creator_id, presence: true
   validate :can_create_private_models
   validates :viewcount, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
-  validates :owners, length: { minimum: 1 }
 
   after_initialize :init
+  after_create :make_creator_owner
 
   scope :is_private, -> { where(is_private: true) }
   scope :is_public, -> { where(is_private: false) }
@@ -122,5 +122,9 @@ class Space < ActiveRecord::Base
 
   def cleaned_guesstimates
     clean_items('guesstimates', 'metric')
+  end
+
+  def make_creator_owner
+    ownerships.create!(user: creator)
   end
 end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -7,10 +7,6 @@ class Space < ActiveRecord::Base
   has_many :ownerships, -> { own }, class_name: "UserSpacePermission"
   has_many :owners, through: :ownerships, source: :user
 
-  def owned_by?(user)
-    owners.exists? user
-  end
-
   belongs_to :creator, class_name: "User"
 
   belongs_to :copied_from, :class_name => 'Space', foreign_key: 'copied_from_id'
@@ -52,6 +48,10 @@ class Space < ActiveRecord::Base
     attribute :metric_count do
       metrics.length.to_i
     end
+  end
+
+  def owned_by?(user)
+    owners.exists? user
   end
 
   def metrics

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,15 @@
 class User < ActiveRecord::Base
-  has_many :spaces
+  has_many :permissions, class_name: "UserSpacePermission"
+  has_many :spaces, through: :permissions
+
+  def owned_spaces
+    spaces.merge(UserSpacePermission.own)
+  end
+
+  has_many :created_spaces, class_name: "Space", foreign_key: "creator_id"
+
   has_one :account, dependent: :destroy
+
   after_create :create_account
 
   validates_uniqueness_of :username, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,10 @@ class User < ActiveRecord::Base
   def ensure_account
     account || create_account
   end
+
+  def spaces_visible_by(user)
+    all_spaces = (spaces.all + created_spaces.all).uniq # A hack until all spaces have ownership permisisons.
+    all_spaces.keep_if { |space| space.is_public? || space.owned_by?(user)}
+    all_spaces
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,8 @@
 class User < ActiveRecord::Base
   has_many :permissions, class_name: "UserSpacePermission"
   has_many :spaces, through: :permissions
-
-  def owned_spaces
-    spaces.merge(UserSpacePermission.own)
-  end
+  has_many :ownerships, -> { own }, class_name: "UserSpacePermission"
+  has_many :owned_spaces, through: :ownerships, source: "space"
 
   has_many :created_spaces, class_name: "Space", foreign_key: "creator_id"
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,5 @@ class User < ActiveRecord::Base
   def spaces_visible_by(user)
     all_spaces = (spaces.all + created_spaces.all).uniq # A hack until all spaces have ownership permisisons.
     all_spaces.keep_if { |space| space.is_public? || space.owned_by?(user)}
-    all_spaces
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  has_many :permissions, class_name: "UserSpacePermission"
+  has_many :permissions, class_name: "UserSpacePermission", dependent: :destroy
   has_many :spaces, through: :permissions
   has_many :ownerships, -> { own }, class_name: "UserSpacePermission"
   has_many :owned_spaces, through: :ownerships, source: "space"

--- a/app/models/user_space_permission.rb
+++ b/app/models/user_space_permission.rb
@@ -1,0 +1,6 @@
+class UserSpacePermission < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :space
+
+  enum access_type: [ :own ]
+end

--- a/app/models/user_space_permission.rb
+++ b/app/models/user_space_permission.rb
@@ -2,5 +2,7 @@ class UserSpacePermission < ActiveRecord::Base
   belongs_to :user
   belongs_to :space
 
-  enum access_type: [ :own ]
+  enum access_type: { own: 1 }
+
+  validates_presence_of :user, :space, :access_type
 end

--- a/app/representers/space_representer.rb
+++ b/app/representers/space_representer.rb
@@ -11,9 +11,9 @@ class SpaceRepresenter < Roar::Decorator
   property :updated_at
   property :graph
   property :is_private
-  property :user_id
+  property :creator_id, as: :user_id
 
-  property :user, class: User, embedded: true  do
+  property :creator, as: :user, class: User, embedded: true  do
     property :id
     property :name
     property :picture

--- a/app/representers/spaces_representer.rb
+++ b/app/representers/spaces_representer.rb
@@ -11,6 +11,6 @@ class SpacesRepresenter < Roar::Decorator
     property :created_at
     property :updated_at
     property :is_private
-    property :user_id
+    property :creator_id, as: :user_id
   end
 end

--- a/db/migrate/20160321063824_create_user_space_permissions.rb
+++ b/db/migrate/20160321063824_create_user_space_permissions.rb
@@ -1,0 +1,13 @@
+class CreateUserSpacePermissions < ActiveRecord::Migration
+  def change
+    create_table :user_space_permissions do |t|
+      t.integer :space_id
+      t.integer :user_id
+      t.integer :access_type
+
+      t.timestamps null: false
+    end
+    add_index :user_space_permissions, :space_id
+    add_index :user_space_permissions, :user_id
+  end
+end

--- a/db/migrate/20160321064528_change_space_user_id.rb
+++ b/db/migrate/20160321064528_change_space_user_id.rb
@@ -1,0 +1,5 @@
+class ChangeSpaceUserId < ActiveRecord::Migration
+  def change
+    rename_column :spaces, :user_id, :creator_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309205108) do
+ActiveRecord::Schema.define(version: 20160321064528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,11 +27,22 @@ ActiveRecord::Schema.define(version: 20160309205108) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.json     "graph"
-    t.integer  "user_id"
+    t.integer  "creator_id"
     t.boolean  "is_private"
     t.integer  "copied_from_id"
     t.integer  "viewcount"
   end
+
+  create_table "user_space_permissions", force: :cascade do |t|
+    t.integer  "space_id"
+    t.integer  "user_id"
+    t.integer  "access_type"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "user_space_permissions", ["space_id"], name: "index_user_space_permissions_on_space_id", using: :btree
+  add_index "user_space_permissions", ["user_id"], name: "index_user_space_permissions_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories/space_factory.rb
+++ b/spec/factories/space_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :space do
-    user
+    association :creator, factory: :user
   end
 end

--- a/spec/factories/user_space_permissions.rb
+++ b/spec/factories/user_space_permissions.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user_space_permission do
-    space_id 1
-    user_id 1
+    space
+    user
     access_type 1
   end
 end

--- a/spec/factories/user_space_permissions.rb
+++ b/spec/factories/user_space_permissions.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :user_space_permission do
+    space_id 1
+    user_id 1
+    access_type 1
+  end
+end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe Space, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    context 'creator should be owner' do
+      it 'should make the creator an owner upon save' do
+        space.save
+        expect(space.owners.count).to eq 1
+        expect(space.owners.first).to eq creator
+      end
+    end
   end
 
   describe '#searchable' do

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 
 RSpec.describe Space, type: :model do
   describe '#create' do
-    let (:user) { FactoryGirl.create(:user) }
+    let (:creator) { FactoryGirl.create(:user) }
     let (:viewcount) { nil } # default context unviewed.
     let (:is_private) { false } # default context public.
 
-    subject (:space) { FactoryGirl.build(:space, user: user, is_private: is_private, viewcount: viewcount) }
+    subject (:space) { FactoryGirl.build(:space, creator: creator, is_private: is_private, viewcount: viewcount) }
 
     # A public, unviewed space should be valid.
     it { is_expected.to be_valid } 
@@ -20,12 +20,12 @@ RSpec.describe Space, type: :model do
     context 'private space' do
       let(:is_private) { true }
 
-      context 'with user on free plan' do
+      context 'with creator on free plan' do
         it { is_expected.not_to be_valid }
       end
 
-      context 'with user on lite plan' do
-        let (:user) { FactoryGirl.create(:user, :lite_plan) }
+      context 'with creator on lite plan' do
+        let (:creator) { FactoryGirl.create(:user, :lite_plan) }
         it { is_expected.to be_valid }
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Space, type: :model do
 
   describe '#copy' do
     # We hardcode the id to make the graph valid.
-    let(:base_user) { FactoryGirl.create(:user, username: 'base_user') }
+    let(:creator) { FactoryGirl.create(:user, username: 'creator') }
     let(:copying_user) { FactoryGirl.create(:user, username: 'copying_user') }
     let(:graph) {
       {'metrics'=>
@@ -75,7 +75,7 @@ RSpec.describe Space, type: :model do
          {'metric'=>'5', 'input'=>'=lognormal(AR,QK)', 'guesstimateType'=>'FUNCTION', 'description'=>''},
          {'metric'=>'6', 'input'=>'[1,3]', 'guesstimateType'=>'NORMAL', 'description'=>''}]}
     }
-    let(:space) { FactoryGirl.create(:space, user: base_user, graph: graph) }
+    let(:space) { FactoryGirl.create(:space, creator: creator, graph: graph) }
 
     subject(:copy) {space.copy(copying_user)}
 
@@ -86,7 +86,7 @@ RSpec.describe Space, type: :model do
       expect(space.copies.first).to eq copy
 
       expect(copy.name).to eq space.name
-      expect(copy.user).to be copying_user
+      expect(copy.creator).to be copying_user
 
       copy.save!
 
@@ -100,7 +100,7 @@ RSpec.describe Space, type: :model do
 
       it 'should copy properly' do
         expect(copy.name).to eq space.name
-        expect(copy.user).to be copying_user
+        expect(copy.creator).to be copying_user
         expect(copy.id).not_to eq space.id
         expect(copy.graph).to be nil
       end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe Space, type: :model do
 
       expect(copy.name).to eq space.name
       expect(copy.creator).to be copying_user
+      expect(copy.owners.count).to eq 1
+      expect(copy.owners.first).to eq copying_user
 
       copy.save!
 

--- a/spec/models/user_space_permission_spec.rb
+++ b/spec/models/user_space_permission_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe UserSpacePermission, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#create' do
+    let (:user) { FactoryGirl.create(:user) }
+    let (:space) { FactoryGirl.create(:space) }
+    let (:access_type) { :own }
+
+    subject (:permission) { FactoryGirl.build(:user_space_permission, user: user, space: space, access_type: access_type) }
+
+    it { is_expected.to be_valid }
+
+    context 'no user' do
+      let (:user) { nil }
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'no space' do
+      let (:space) { nil }
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'no access_type' do
+      let (:access_type) { nil }
+      it { is_expected.not_to be_valid }
+    end
+  end
 end

--- a/spec/models/user_space_permission_spec.rb
+++ b/spec/models/user_space_permission_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserSpacePermission, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This assigns model ownership to users via a join model, making the association many to many. This will serve as the server side bedrock for sharing.

API features will be done separately; wanted to get the basic model functionality out first. API changes will be done in two batches; updating the client and the representers to list all owning users (rather than just the creator), and adding a server endpoint for sharing a space.