### PR TITLE
Modifying the representer to return users with spaces in the spaces representer.

### DIFF
--- a/app/representers/spaces_representer.rb
+++ b/app/representers/spaces_representer.rb
@@ -13,5 +13,11 @@ class SpacesRepresenter < Roar::Decorator
     property :is_private
     property :user_id
     property :organization_id
+
+    property :user, class: User, embedded: true do
+      property :id
+      property :name
+      property :picture
+    end
   end
 end


### PR DESCRIPTION
This enables organizational pages to show their spaces' authors.