### PR TITLE
Fact snapshots.

### DIFF
--- a/app/controllers/facts_controller.rb
+++ b/app/controllers/facts_controller.rb
@@ -17,18 +17,19 @@ class FactsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /organizations/:organization_id/facts/1
-  # PATCH/PUT /organizations/:organization_id/facts/1.json
+  # PATCH/PUT /organizations/:organization_id/facts/:id
+  # PATCH/PUT /organizations/:organization_id/facts/:id.json
   def update
     if @fact.update(fact_params)
+      @fact.take_checkpoint(current_user)
       render json: FactRepresenter.new(@fact).to_json, status: :ok
     else
       render json: @fact.errors, status: :unprocessable_entity
     end
   end
 
-  # DELETE /organizations/:organization_id/facts/1
-  # DELETE /organizations/:organization_id/facts/1.json
+  # DELETE /organizations/:organization_id/facts/:id
+  # DELETE /organizations/:organization_id/facts/:id.json
   def destroy
     @fact.destroy
     head :no_content

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -30,7 +30,7 @@ class Fact < ActiveRecord::Base
   def fact_has_stats
     stats = simulation && simulation['stats']
     stats_present_and_valid = stats && (
-      stats['length'] == 1 || (stats['percentiles'] && stats['percentiles']['5'] && stats['percentiles']['95'])
+      stats['length'].to_i == 1 || (stats['percentiles'] && stats['percentiles']['5'] && stats['percentiles']['95'])
     )
     errors[:base] << 'must have stats' unless stats_present_and_valid
   end

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -6,7 +6,7 @@ class Fact < ActiveRecord::Base
   validates :variable_name,
     uniqueness: {scope: :organization_id},
     format: {with: /\A\w+\Z/}
-  validate :fact_has_values, :fact_has_no_errors
+  validate :fact_has_values, :fact_has_no_errors, :fact_has_stats
 
   CHECKPOINT_LIMIT = 1000
 
@@ -27,6 +27,13 @@ class Fact < ActiveRecord::Base
 
   private
 
+  def fact_has_stats
+    stats = simulation && simulation['stats']
+    stats_present_and_valid = stats && (
+      stats['length'] == 1 || (stats['percentiles'] && stats['percentiles']['5'] && stats['percentiles']['95'])
+    )
+    errors[:base] << 'must have stats' unless stats_present_and_valid
+  end
   def fact_has_values
     values_present = simulation && simulation['sample'] && simulation['sample']['values'] && simulation['sample']['values'].length > 0
     errors[:base] << 'must have values' unless values_present

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -8,6 +8,23 @@ class Fact < ActiveRecord::Base
     format: {with: /\A\w+\Z/}
   validate :fact_has_values, :fact_has_no_errors
 
+  CHECKPOINT_LIMIT = 1000
+
+  def take_checkpoint(author)
+    checkpoint = checkpoints.create(
+      author: author,
+      simulation: simulation,
+      name: name,
+      variable_name: variable_name,
+      expression: expression,
+    )
+    num_checkpoints = checkpoints.count
+    if num_checkpoints > CHECKPOINT_LIMIT
+      checkpoints.order('created_at').limit(num_checkpoints - CHECKPOINT_LIMIT).destroy_all
+    end
+    return checkpoint
+  end
+
   private
 
   def fact_has_values

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -1,5 +1,6 @@
 class Fact < ActiveRecord::Base
   belongs_to :organization
+  has_many :checkpoints, class_name: 'FactCheckpoint', dependent: :destroy
 
   validates_presence_of :organization, :variable_name, :expression, :simulation
   validates :variable_name,

--- a/app/models/fact_checkpoint.rb
+++ b/app/models/fact_checkpoint.rb
@@ -3,18 +3,4 @@ class FactCheckpoint < ActiveRecord::Base
   belongs_to :author, class_name: 'User'
 
   validates_presence_of :fact, :simulation, :author
-
-  def self.build_from_fact(fact, author)
-    fact.checkpoints.new(
-      author: author,
-      simulation: fact.simulation,
-      name: fact.name,
-      variable_name: fact.variable_name,
-      expression: fact.expression,
-    )
-  end
-  def self.create_from_fact(fact, author)
-    FactCheckpoint.build_from_fact(fact, author).save!
-  end
-
 end

--- a/app/models/fact_checkpoint.rb
+++ b/app/models/fact_checkpoint.rb
@@ -1,0 +1,20 @@
+class FactCheckpoint < ActiveRecord::Base
+  belongs_to :fact
+  belongs_to :author, class_name: 'User'
+
+  validates_presence_of :fact, :simulation, :author
+
+  def self.build_from_fact(fact, author)
+    fact.checkpoints.new(
+      author: author,
+      simulation: fact.simulation,
+      name: fact.name,
+      variable_name: fact.variable_name,
+      expression: fact.expression,
+    )
+  end
+  def self.create_from_fact(fact, author)
+    FactCheckpoint.build_from_fact(fact, author).save!
+  end
+
+end

--- a/db/migrate/20160809220951_create_fact_checkpoints.rb
+++ b/db/migrate/20160809220951_create_fact_checkpoints.rb
@@ -1,0 +1,18 @@
+class CreateFactCheckpoints < ActiveRecord::Migration
+  def change
+    create_table :fact_checkpoints do |t|
+      t.integer :fact_id
+      t.integer :author_id
+      t.json :simulation
+      t.string :name
+      t.string :variable_name
+      t.string :expression
+
+      t.timestamps null: false
+    end
+
+    add_index :fact_checkpoints, :fact_id
+    add_index :fact_checkpoints, :author_id
+    add_index :fact_checkpoints, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801183442) do
+ActiveRecord::Schema.define(version: 20160809220951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,21 @@ ActiveRecord::Schema.define(version: 20160801183442) do
   end
 
   add_index "calculators", ["space_id"], name: "index_calculators_on_space_id", using: :btree
+
+  create_table "fact_checkpoints", force: :cascade do |t|
+    t.integer  "fact_id"
+    t.integer  "author_id"
+    t.json     "simulation"
+    t.string   "name"
+    t.string   "variable_name"
+    t.string   "expression"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "fact_checkpoints", ["author_id"], name: "index_fact_checkpoints_on_author_id", using: :btree
+  add_index "fact_checkpoints", ["created_at"], name: "index_fact_checkpoints_on_created_at", using: :btree
+  add_index "fact_checkpoints", ["fact_id"], name: "index_fact_checkpoints_on_fact_id", using: :btree
 
   create_table "facts", force: :cascade do |t|
     t.integer  "organization_id"

--- a/spec/controllers/facts_spec.rb
+++ b/spec/controllers/facts_spec.rb
@@ -4,7 +4,7 @@ require 'rspec/collection_matchers'
 
 def setup_knock(user)
   request.headers['authorization'] = 'Bearer JWTTOKEN'
-  knock = double("Knock")
+  knock = double('Knock')
   allow(knock).to receive(:current_user).and_return(user)
   allow(knock).to receive(:validate!).and_return(true)
   allow(Knock::AuthToken).to receive(:new).and_return(knock)
@@ -19,8 +19,8 @@ RSpec.describe FactsController, type: :controller do
       expression: '100',
       variable_name: 'var_1',
       simulation: {
-        "sample" => {"values" => [100], "errors" => []},
-        "stats" => {"mean" => 100, "stdev" => 0, "length" => 0}
+        'sample' => {'values' => [100], 'errors' => []},
+        'stats' => {'mean' => 100, 'stdev' => 0, 'length' => 1}
       }
     }}
 
@@ -71,8 +71,8 @@ RSpec.describe FactsController, type: :controller do
       expression: '100',
       variable_name: 'var_1',
       simulation: {
-        "sample" => {"values" => [100], "errors" => []},
-        "stats" => {"mean" => 100, "stdev" => 0, "length" => 0}
+        'sample' => {'values' => [100], 'errors' => []},
+        'stats' => {'mean' => 100, 'stdev' => 0, 'length' => 1}
       }
     }}
 

--- a/spec/controllers/facts_spec.rb
+++ b/spec/controllers/facts_spec.rb
@@ -91,9 +91,6 @@ RSpec.describe FactsController, type: :controller do
     end
 
     it 'should successfully take a checkpoint' do
-      # TODO(Ozzie): If you know of a (quick) way to get this to check if the `take_checkpoint` method is called,
-      # that'd be preferrable, but my attempts to do so haven't worked.
-
       # It should start with no checkpoints
       expect(fact.checkpoints.count).to be 0
 

--- a/spec/factories/fact_checkpoints.rb
+++ b/spec/factories/fact_checkpoints.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :fact_checkpoint do
-    simulation JSON.generate  sample: {values: [1], errors: []}, stats: {mean: 1, stdev: 0, length: 1}
+    simulation JSON.generate sample: {values: [1], errors: []}, stats: {mean: 1, stdev: 0, length: 1}
 
     fact
     association :author, :factory => :user

--- a/spec/factories/fact_checkpoints.rb
+++ b/spec/factories/fact_checkpoints.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :fact_checkpoint do
+    simulation JSON.generate  sample: {values: [1], errors: []}, stats: {mean: 1, stdev: 0, length: 1}
+
+    fact
+    association :author, :factory => :user
+  end
+end

--- a/spec/models/fact_checkpoint_spec.rb
+++ b/spec/models/fact_checkpoint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FactCheckpoint, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/fact_checkpoint_spec.rb
+++ b/spec/models/fact_checkpoint_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe FactCheckpoint, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#create' do
+    let (:fact) { FactoryGirl.create(:fact) }
+    let (:author) { FactoryGirl.create(:user) }
+    let (:simulation) { JSON.generate sample: {values: [1], errors: []}, stats: {mean: 1, stdev: 0, length: 1} }
+
+    subject (:checkpoint) { FactoryGirl.build(:fact_checkpoint, fact: fact, simulation: simulation, author: author) }
+
+    it { is_expected.to be_valid }
+
+    context 'No fact' do
+      let (:fact) {nil}
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'No simulation' do
+      let (:simulation) {nil}
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'No author' do
+      let (:author) {nil}
+      it { is_expected.not_to be_valid }
+    end
+  end
 end

--- a/spec/models/fact_spec.rb
+++ b/spec/models/fact_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Fact, type: :model do
     let (:name) { 'name' }
     let (:expression) { '199' }
     let (:variable_name) { 'var_1' }
-    let (:simulation) { {"sample" => { "values" => [1], "errors" => [] }, "stats" => { "mean" => 1, "stdev" => 0, "length" => 1 }} }
+    let (:stats) { {"mean" => 1, "stdev" => 0, "length" => 1} }
+    let (:values) { [1] }
+    let (:errors) { [] }
+    let (:simulation) { {"sample" => {"values" => values, "errors" => errors}, "stats" => stats} }
     subject (:fact) {
       FactoryGirl.build(
         :fact,
@@ -60,12 +63,23 @@ RSpec.describe Fact, type: :model do
     end
 
     context 'simulation with no values' do
-      let (:simulation) { {"sample" => {}} }
+      let (:values) { nil }
       it { is_expected.to_not be_valid }
     end
 
     context 'simulation with errors' do
-      let (:simulation) { {"sample" => {"values" => [1], "errors" => [{"type" => "Math Error", "msg" => "Invalid Sample"}]}} }
+      let (:errors) { [{"type" => "Math Error", "msg" => "Invalid Sample"}] }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'simulation with no stats' do
+      let (:stats) { nil }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'simulation with multiple samples and no percentiles' do
+      let (:values) { [1,2,3] }
+      let (:stats) { {"mean" => 0.5, "length" => 3, "stdev" => 1} }
       it { is_expected.to_not be_valid }
     end
   end


### PR DESCRIPTION
These contain more information than just the simulations, which is what we'd care about from a UI perspective, but that other information would be useful for restoring facts to old states in case of unintended deletion, can be ignored when we pass the relevant checkpoints down to the user for graphing, and won't contribute any significant space overhead relative to the simulations, which are much larger.