### PR TITLE
Make space update return to the client an updated list of imported fact ids.

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -20,7 +20,8 @@ class Space < ActiveRecord::Base
   validates_presence_of :is_private, if: :shareable_link_enabled # Booleans are only considered 'present' on 'true'
 
   after_initialize :init
-  after_save :identify_user, :update_imported_fact_ids!
+  after_save :identify_user
+  before_save :update_imported_fact_ids!
   after_destroy :identify_user
 
   scope :is_private, -> { where(is_private: true) }
@@ -82,7 +83,7 @@ class Space < ActiveRecord::Base
   end
 
   def update_imported_fact_ids!()
-    update_columns(imported_fact_ids: get_imported_fact_ids)
+    self.imported_fact_ids = get_imported_fact_ids
   end
 
   def metrics

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -193,6 +193,24 @@ RSpec.describe Space, type: :model do
     end
   end
 
+  describe '#save' do
+    subject(:space) { FactoryGirl.create(:space) }
+    let(:new_graph) {
+      {
+        'guesstimates' => [
+          {'expression'=>'=${fact:1} + ${fact:2} + ${fact:1}'},
+          {'expression'=>'=${fact:2} + ${fact:3} + ${fact:40}'},
+          {'expression'=>'=${fact:1} + ${fact:2} + fact:77'}
+        ]
+      }
+    }
+
+    it 'updates imported_fact_ids' do
+      expect{space.update! graph: new_graph}.to change{space.imported_fact_ids}.from([])
+      expect(space.imported_fact_ids).to contain_exactly(1, 2, 3, 40)
+    end
+  end
+
   describe '#get_imported_fact_ids' do
     let(:guesstimates) { [] }
     let(:space) { FactoryGirl.build(:space, graph: guesstimates.empty? ? nil : {'guesstimates' => guesstimates}) }


### PR DESCRIPTION
Use before save instead of after save so that space updates return to the client an updated list of imported fact ids.