### PR TITLE
Track Ruby errors with sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'sass-rails'
 
 # Analytics & Reporting
 gem 'analytics-ruby', '~> 2.0.0', require: 'segment/analytics'
+gem 'sentry-raven'
 
 # Caching
 gem 'actionpack-action_caching'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -120,6 +122,7 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     multi_xml (0.5.5)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -223,6 +226,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     sequel (4.36.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -295,6 +300,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   sdoc (~> 0.4.0)
+  sentry-raven
   shoulda-matchers
   skylight
   spring

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.dsn = Rails.application.secrets.sentry_dsn
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -68,3 +68,4 @@ production:
     port: <%= ENV["ANALYTICS_DATABASE_PORT"] %>
     user: <%= ENV["ANALYTICS_DATABASE_USER"] %>
     password: <%= ENV["ANALYTICS_DATABASE_PASSWORD"] %>
+  sentry_url: <%= ENV["SENTRY_DSN"] %>


### PR DESCRIPTION
This requires that the `SENTRY_DSN` environment variable be set.

If it's not set (as in the development and test environments), there will be some logging like this:

```
lolololol excluded from capture: DSN not set
```

If you're signed in to Sentry, you can get the DSN here: https://docs.sentry.io/clients/ruby/#configuration

It's obfuscated but you can copy-paste it.