### PR TITLE
Add endpoint for testing handling of errors

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,5 @@
+class AdminController < ApplicationController
+  def bad_show
+    raise "Test error"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,8 @@ Rails.application.routes.draw do
   end
 
   resources :user_organization_memberships, only: [:destroy]
+
+  namespace :admin do
+    get :bad_show
+  end
 end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe AdminController, type: :controller do
+  describe "#bad_show" do
+    it "raises an exception" do
+      expect {
+        get :bad_show
+      }.to raise_error("Test error")
+    end
+  end
+end


### PR DESCRIPTION
This is to test that 500s are handled correctly (e.g., that they show up
in Sentry).