### PR TITLE
Update binstubs

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
+APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/update
+++ b/bin/update
@@ -10,8 +10,8 @@ def system!(*args)
 end
 
 chdir APP_ROOT do
-  # This script is a starting point to setup your application.
-  # Add necessary setup steps to this file.
+  # This script is a way to update your development environment automatically.
+  # Add necessary update steps to this file.
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
@@ -20,13 +20,8 @@ chdir APP_ROOT do
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
-
-  puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  puts "\n== Updating database =="
+  system! 'bin/rails db:migrate'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+APP_ROOT = File.expand_path('..', __dir__)
+Dir.chdir(APP_ROOT) do
+  begin
+    exec "yarnpkg", *ARGV
+  rescue Errno::ENOENT
+    $stderr.puts "Yarn executable was not detected in the system."
+    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    exit 1
+  end
+end


### PR DESCRIPTION
The new versions were created by running `rails app:update`. These
changes prevent this warning from being printed when you run `rails
server`:

    ~/projects/guesstimate-server master ➜ rails s
    Array values in the parameter to `Gem.paths=` are deprecated.
    Please use a String or nil.
    An Array ({"GEM_PATH"=>["/home/pat/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0", "/home/pat/.gem/ruby/2.5.0"]}) was passed in from bin/rails:3:in `load'