### PR TITLE
Remove Logentries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,5 +57,4 @@ end
 
 group :production do
   gem 'skylight'
-  gem 'le'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,6 @@ GEM
       bcrypt (~> 3.1)
       jwt (~> 1.5)
       rails (>= 4.2)
-    le (2.7.6)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -239,7 +238,6 @@ DEPENDENCIES
   dalli
   factory_bot_rails
   knock (~> 2.0)
-  le
   multi_json
   pg
   pry

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,9 +59,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a logentries logger for distributed setups.
-  config.logger = Le.new('b3f94a58-f3f0-32d2-86b4-59656185a2df', :debug => true, :local => true)
-
   # Use a different cache store in production.
   config.cache_store = :dalli_store,
     (Rails.application.secrets.memcachedcloud_servers || "").split(","), {


### PR DESCRIPTION
It was causing a segfault on Heroku:

    882019-03-29T06:08:03.740205+00:00 app[web.1]: /app/vendor/bundle/ruby/2.5.0/gems/le-2.7.6/lib/le/host/http.rb:136: [BUG] Segmentation fault at 0x00007fec71d6fb8d
    2019-03-29T06:08:03.740228+00:00 app[web.1]: ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
    2019-03-29T06:08:03.740231+00:00 app[web.1]:
    2019-03-29T06:08:03.740234+00:00 app[web.1]: -- Control frame information -----------------------------------------------
    2019-03-29T06:08:03.740240+00:00 app[web.1]: c:0039 p:---- s:0333 e:000332 CFUNC  :push
    2019-03-29T06:08:03.740243+00:00 app[web.1]: c:0038 p:0150 s:0328 e:000327 METHOD /app/vendor/bundle/ruby/2.5.0/gems/le-2.7.6/lib/le/host/http.rb:136
    2019-03-29T06:08:03.740245+00:00 app[web.1]: c:0037 p:0030 s:0323 e:000322 BLOCK  /app/vendor/ruby-2.5.1/lib/ruby/2.5.0/logger.rb:697
    2019-03-29T06:08:03.740247+00:00 app[web.1]: c:0036 p:0007 s:0320 e:000319 METHOD /app/vendor/ruby-2.5.1/lib/ruby/2.5.0/monitor.rb:226