### PR TITLE
Add a docker container for postgresql dev server

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: guesstimate-api
+      POSTGRES_DB: guesstimate-api_development
+    ports:
+      - "5432:5432"

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,19 +29,19 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: guesstimate-api
+  username: guesstimate-api
 
   # The password associated with the postgres role (username).
-  #password:
+  password: password
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  port: 5432
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public


### PR DESCRIPTION
Simply adds a compose.yaml file for people who might want to use docker for setting up a dev postgres server. 

Possibly controversial: I also changed the database settings in the config/database.yml to use a TCP port and given username and password rather than a Unix port. This may mean that if you set up a database, you may need to change the username/database name. The docker container is however automatically configured with the correct settings.

It could be worth exposing a Unix port on the docker container, rather than going the TCP route. Benefits being that it should work with any existing dev setup, downsides is that Unix ports are not supported on windows