### PR TITLE
Fix Rails 6.1 deprecation warnings

### DIFF
--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -67,14 +67,14 @@ class Fact < ApplicationRecord
     stats_present_and_valid = stats && (
       stats['length'].to_i == 1 || (stats['percentiles'] && stats['percentiles']['5'] && stats['percentiles']['95'])
     )
-    errors[:base] << 'must have stats' unless stats_present_and_valid
+    errors.add(:base, 'must have stats') unless stats_present_and_valid
   end
   def fact_has_values
     values_present = simulation && simulation['sample'] && simulation['sample']['values'] && simulation['sample']['values'].length > 0
-    errors[:base] << 'must have values' unless values_present
+    errors.add(:base, 'must have values') unless values_present
   end
   def fact_has_no_errors
     errors_present = simulation && simulation['sample'] && simulation['sample']['errors'] && simulation['sample']['errors'].length > 0
-    errors[:base] << 'can not have errors' if errors_present
+    errors.add(:base, 'can not have errors') if errors_present
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module GuesstimateApi
 
     # This is here because some dependencies were causing trouble with Heroku
     config.enable_dependency_loading  = true
+
+    config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
   end
 end


### PR DESCRIPTION
These commits aren't necessary to upgrade to Rails 6.1, so they can be merged independly of the upgrade. This would make a rollback slightly less messy, and it reduces the risk of incidental breakage.
