### PR TITLE
Resolve linked Auth0 identities when provisioning users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Start containers
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
       - name: Prepare DB
-        run: docker-compose run --rm web rails db:prepare
+        run: docker compose run --rm web rails db:prepare
       - name: Run tests
-        run: docker-compose run --rm web bundle exec rspec
+        run: docker compose run --rm web bundle exec rspec

--- a/lib/authentor.rb
+++ b/lib/authentor.rb
@@ -19,9 +19,37 @@ class Authentor
   end
 
   def fetch_user(auth0_id)
-    auth0_user = @auth0.user(auth0_id)
+    begin
+      auth0_user = @auth0.user(auth0_id)
+    rescue Auth0::NotFound
+      # The Management API's user(id) endpoint only resolves *primary* user ids.
+      # When a user signs in with an identity that Auth0 has linked as a
+      # secondary (e.g. a Google login linked under a primary GitHub account),
+      # the token's `sub` is the secondary id and user(id) returns 404.
+      # Fall back to searching identities so we can still find the account.
+      auth0_user = find_user_by_identity(auth0_id)
+      raise if auth0_user.nil?
+      # Store the record under the id the frontend authenticates with, so future
+      # lookups by this `sub` match without another Auth0 round-trip.
+      auth0_user = auth0_user.merge("user_id" => auth0_id)
+    end
+
     user = User.create_from_auth0_user auth0_user
     Rails.logger.info "Created user from auth0 user #{auth0_user}"
+  end
+
+  # Looks up an Auth0 user by a (possibly secondary/linked) identity id.
+  # `auth0_id` looks like "google-oauth2|1107...", and Auth0 stores the part
+  # after the "|" as identities.user_id. Returns the user hash or nil.
+  def find_user_by_identity(auth0_id)
+    identity_user_id = auth0_id.split("|", 2).last
+    result = @auth0.users(
+      q: %Q{identities.user_id:"#{identity_user_id}"},
+      search_engine: "v3",
+      per_page: 1,
+      include_totals: true
+    )
+    (result["users"] || []).first
   end
 
   def fetch_users


### PR DESCRIPTION
## Problem

A user who signs in with an Auth0 identity that has been **linked as a secondary** (e.g. a Google login linked under a primary GitHub account) hits the **"Website Error!"** modal on every page load.

Flow:
1. Frontend calls `GET /users?auth0_id=<sub>`, where `<sub>` is the *secondary* identity id (`google-oauth2|…`).
2. User isn't in the DB, so `Authentor#fetch_user` calls the Auth0 Management API `GET /users/{id}`.
3. That endpoint **only resolves primary ids** → returns 404 (`Auth0::NotFound`).
4. `users_controller` rescues `Auth0::Exception` and returns **HTTP 400**.
5. Frontend `fetchMe` throws → `displayErrors.newError` → error modal.

GitHub login works because that's the primary identity. Existing DB users are unaffected (they skip Auth0 entirely).

## Fix

In `Authentor#fetch_user`, on `Auth0::NotFound`, fall back to searching identities (`identities.user_id:"<id>"`) to find the primary account, then create the local user under the id the frontend authenticates with — so future logins resolve straight from the DB.

## Testing

Reproduced and verified locally against the dev Auth0 tenant:
- Direct `auth0.user(secondary_id)` → 404 (the bug)
- Identity search → resolves the primary account
- `fetch_user` → creates the local user; `GET /users?auth0_id=<secondary>` now returns **200**

## Note

This depends on the Auth0 account-linking fix (the deprecated "Automatically Link Accounts" Rule using the removed `async.each` was ported to a post-login Action). That change lives in the Auth0 tenant / ops, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)