### PR TITLE
Return full Chargebee hosted page object for in-context checkout

### DIFF
--- a/lib/external_subscriptions/adapter.rb
+++ b/lib/external_subscriptions/adapter.rb
@@ -4,6 +4,15 @@ module ExternalSubscriptions
 
     class << self
       def new_subscription_iframe_url(entity_id, plan_id)
+        return new_subscription_hosted_page(entity_id, plan_id)["url"]
+      end
+
+      # Returns the full Chargebee hosted page object (id, type, url, state,
+      # embed, ...). Chargebee.js v2 needs the whole object passed to
+      # openCheckout's `hostedPage` callback so the checkout runs in-context and
+      # fires the `success` callback (which triggers our account sync). Passing
+      # only the url makes Chargebee redirect on success, and the sync is lost.
+      def new_subscription_hosted_page(entity_id, plan_id)
         params = {
           subscription: {
             plan_id: plan_id
@@ -14,7 +23,7 @@ module ExternalSubscriptions
           embed: true,
           iframe_messaging: true
         }
-        return ChargeBee::HostedPage.checkout_new(params).hosted_page.url
+        return ChargeBee::HostedPage.checkout_new(params).get_raw_response[:hosted_page]
       end
 
       def create_subscription(entity_id, plan_id)

--- a/lib/external_subscriptions/new_subscription_iframe.rb
+++ b/lib/external_subscriptions/new_subscription_iframe.rb
@@ -1,14 +1,18 @@
 module ExternalSubscriptions
   class NewSubscriptionIframe
-    attr_accessor :href, :website_name
+    attr_accessor :hosted_page, :website_name
 
     def initialize(user_id, plan_id)
-      @href = Adapter.new_subscription_iframe_url(user_id, plan_id)
+      @hosted_page = Adapter.new_subscription_hosted_page(user_id, plan_id)
     end
 
     def attributes
       return {
-        href: @href,
+        # Full Chargebee hosted page object, passed to Chargebee.js v2
+        # openCheckout's `hostedPage` callback for in-context checkout.
+        hosted_page: @hosted_page,
+        # Kept for backwards compatibility with older clients.
+        href: @hosted_page && @hosted_page[:url],
         website_name: Rails.application.secrets[:chargebee_site]
       }
     end


### PR DESCRIPTION
After a real payment in prod, Chargebee redirected instead of firing the success callback, so the account stayed on the free plan. Chargebee.js v2 only runs in-context (and fires `success`, which triggers our account sync) when `openCheckout` gets the full hosted page object — a bare URL triggers redirect mode.

This returns the full hosted page object from `/users/:id/new_subscription_iframe` (keeping `href` for older clients).

Companion frontend PR: getguesstimate/guesstimate-app (passes the object to `openCheckout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)