### PR TITLE
Add Chargebee webhooks + fix re-subscribe and cancel sync

### DIFF
--- a/app/controllers/chargebee_webhooks_controller.rb
+++ b/app/controllers/chargebee_webhooks_controller.rb
@@ -1,0 +1,30 @@
+class ChargebeeWebhooksController < ApplicationController
+  before_action :authenticate_webhook!
+
+  # POST /chargebee/webhooks
+  # Chargebee pushes every billing event here (subscription created, cancelled,
+  # renewed, changed, ...). We don't trust the payload contents; we just take
+  # the customer id and re-sync that user's account from the Chargebee API.
+  def create
+    user = User.find_by(id: customer_id)
+    user.account.synchronize! if user
+    render json: {}
+  end
+
+  private
+
+  def customer_id
+    params.dig(:content, :customer, :id) ||
+      params.dig(:content, :subscription, :customer_id)
+  end
+
+  def authenticate_webhook!
+    authenticate_or_request_with_http_basic('chargebee') do |username, password|
+      expected_username = Rails.application.secrets[:chargebee_webhook_username].to_s
+      expected_password = Rails.application.secrets[:chargebee_webhook_password].to_s
+      expected_password.present? &&
+        ActiveSupport::SecurityUtils.secure_compare(username, expected_username) &
+        ActiveSupport::SecurityUtils.secure_compare(password, expected_password)
+    end
+  end
+end

--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -2,7 +2,9 @@ class UserAccount < ApplicationRecord
   belongs_to :user
 
   def new_subscription_iframe(plan_id)
-    return false if has_payment_account
+    # Only block users who already have a live paid plan. Users with a payment
+    # account but a cancelled subscription must be able to subscribe again.
+    return false if has_payment_account && !user.personal_free?
     return ExternalSubscriptions::NewSubscriptionIframe.new(user.id, plan_id)
   end
 
@@ -25,7 +27,8 @@ class UserAccount < ApplicationRecord
   ## TODO: Add error if the external_subscription does not match something in the database
   def synchronize_subscription!
     return false unless has_payment_account
-    user.update_attribute(:plan, external_subscription)
+    # No live subscription (e.g. cancelled) means the user is back on free.
+    user.update_attribute(:plan, external_subscription || 'personal_free')
   end
 
   def external_has_account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
 
   mount Knock::Engine => '/knock'
 
+  post '/chargebee/webhooks', to: 'chargebee_webhooks#create'
+
   resources :calculators, only: [:show, :update, :destroy]
 
   resources :spaces, only: [:show, :create, :update, :destroy]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,6 +11,8 @@ development:
   algolia_api_key: 6801f2d2f73fe7364696ad43fc65689c
   chargebee_site: guesstimate-test
   chargebee_api_key: test_8KGVtKWvLDecuvvBYmDr5HcdqyKEW4ymWe
+  chargebee_webhook_username: chargebee
+  chargebee_webhook_password: dev-webhook-password
   urlbox_api_key: fake
   urlbox_secret: fake
 
@@ -19,6 +21,8 @@ test:
   algolia_api_key: fake
   chargebee_site: fake
   chargebee_api_key: fake
+  chargebee_webhook_username: chargebee
+  chargebee_webhook_password: test-webhook-password
   auth0_audience: fake
   auth0_api_domain: guesstimate-development.auth0.com
 
@@ -34,6 +38,8 @@ production:
   algolia_api_key: <%= ENV["ALGOLIA_API_KEY"] %>
   chargebee_site: guesstimate
   chargebee_api_key: <%= ENV['CHARGEBEE_API_KEY'] %>
+  chargebee_webhook_username: <%= ENV['CHARGEBEE_WEBHOOK_USERNAME'] %>
+  chargebee_webhook_password: <%= ENV['CHARGEBEE_WEBHOOK_PASSWORD'] %>
   urlbox_api_key: <%= ENV['URLBOX_API_KEY'] %>
   urlbox_secret: <%= ENV['URLBOX_SECRET'] %>
   sendgrid_username: <%= ENV['SENDGRID_USERNAME'] %>

--- a/lib/external_subscriptions/adapter.rb
+++ b/lib/external_subscriptions/adapter.rb
@@ -12,18 +12,40 @@ module ExternalSubscriptions
       # openCheckout's `hostedPage` callback so the checkout runs in-context and
       # fires the `success` callback (which triggers our account sync). Passing
       # only the url makes Chargebee redirect on success, and the sync is lost.
+      #
+      # The site allows one subscription per customer, so checkout_new is
+      # rejected once a subscription exists in any state (even cancelled).
+      # Returning customers go through checkout_existing instead, which
+      # reactivates a cancelled subscription on completion.
       def new_subscription_hosted_page(entity_id, plan_id)
-        params = {
-          subscription: {
-            plan_id: plan_id
-          },
-          customer: {
-            id: entity_id
-          },
-          embed: true,
-          iframe_messaging: true
-        }
-        return ChargeBee::HostedPage.checkout_new(params).get_raw_response[:hosted_page]
+        existing = any_subscription(entity_id)
+        if existing
+          params = {
+            subscription: {
+              id: existing.id,
+              plan_id: plan_id
+            },
+            # Without this a checkout on a cancelled subscription only saves
+            # the changes; the subscription stays cancelled and nothing is
+            # charged.
+            reactivate: existing.status == 'cancelled',
+            embed: true,
+            iframe_messaging: true
+          }
+          return ChargeBee::HostedPage.checkout_existing(params).get_raw_response[:hosted_page]
+        else
+          params = {
+            subscription: {
+              plan_id: plan_id
+            },
+            customer: {
+              id: entity_id
+            },
+            embed: true,
+            iframe_messaging: true
+          }
+          return ChargeBee::HostedPage.checkout_new(params).get_raw_response[:hosted_page]
+        end
       end
 
       def create_subscription(entity_id, plan_id)
@@ -60,14 +82,29 @@ module ExternalSubscriptions
         return true
       end
 
+      # Statuses that entitle the customer to the plan. A cancelled or paused
+      # subscription must not count, otherwise cancelling never downgrades.
+      LIVE_SUBSCRIPTION_STATUSES = %w[future in_trial active non_renewing].freeze
+
       def subscription(entity_id)
         subscriptions = ChargeBee::Subscription.subscriptions_for_customer(entity_id, :limit => 5).to_a
-        return subscriptions[0].try(:subscription).try(:plan_id)
+        live = subscriptions.find { |s| LIVE_SUBSCRIPTION_STATUSES.include?(s.subscription.status) }
+        return live.try(:subscription).try(:plan_id)
       end
 
       private
       def exception_reveals_no_user(ex)
         ex.try(:cause).try(:http_code) === RESOURCE_NOT_FOUND_ERROR_CODE
+      end
+
+      # The customer's subscription in any state, or nil for customers
+      # Chargebee doesn't know yet.
+      def any_subscription(entity_id)
+        subscriptions = ChargeBee::Subscription.subscriptions_for_customer(entity_id, :limit => 1).to_a
+        subscriptions[0].try(:subscription)
+      rescue ChargeBee::InvalidRequestError => ex
+        raise ex unless exception_reveals_no_user(ex)
+        nil
       end
     end
   end

--- a/spec/controllers/chargebee_webhooks_spec.rb
+++ b/spec/controllers/chargebee_webhooks_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ChargebeeWebhooksController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  let(:event_params) {
+    { event_type: 'subscription_cancelled', content: { customer: { id: user.id.to_s } } }
+  }
+
+  def authenticate!
+    request.env['HTTP_AUTHORIZATION'] =
+      ActionController::HttpAuthentication::Basic.encode_credentials('chargebee', 'test-webhook-password')
+  end
+
+  describe '#create' do
+    it 'rejects requests without credentials' do
+      post :create, params: event_params
+      expect(response.status).to eq 401
+    end
+
+    it 'rejects requests with wrong credentials' do
+      request.env['HTTP_AUTHORIZATION'] =
+        ActionController::HttpAuthentication::Basic.encode_credentials('chargebee', 'wrong')
+      post :create, params: event_params
+      expect(response.status).to eq 401
+    end
+
+    it 'synchronizes the user account named by content.customer.id' do
+      authenticate!
+      expect_any_instance_of(UserAccount).to receive(:synchronize!)
+      post :create, params: event_params
+      expect(response.status).to eq 200
+    end
+
+    it 'falls back to content.subscription.customer_id' do
+      authenticate!
+      expect_any_instance_of(UserAccount).to receive(:synchronize!)
+      post :create, params: {
+        event_type: 'subscription_changed',
+        content: { subscription: { customer_id: user.id.to_s } }
+      }
+      expect(response.status).to eq 200
+    end
+
+    it 'returns 200 for events about unknown customers' do
+      authenticate!
+      post :create, params: {
+        event_type: 'subscription_created',
+        content: { customer: { id: 'cfgprobe_guesstimate' } }
+      }
+      expect(response.status).to eq 200
+    end
+  end
+end

--- a/spec/lib/external_subscriptions/adapter_spec.rb
+++ b/spec/lib/external_subscriptions/adapter_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ExternalSubscriptions::Adapter do
+  def entry(status, plan_id, id = 'sub_1')
+    OpenStruct.new(subscription: OpenStruct.new(status: status, plan_id: plan_id, id: id))
+  end
+
+  describe '.new_subscription_hosted_page' do
+    let(:result) { double(get_raw_response: { hosted_page: { id: 'hp_1' } }) }
+
+    it 'uses checkout_new for customers without a subscription' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer).and_return([])
+      expect(ChargeBee::HostedPage).to receive(:checkout_new).and_return(result)
+      expect(described_class.new_subscription_hosted_page(1, 'personal_lite')).to eq({ id: 'hp_1' })
+    end
+
+    it 'uses checkout_new for customers unknown to Chargebee' do
+      error = ChargeBee::InvalidRequestError.new(404, OpenStruct.new(message: 'not found'))
+      allow(error).to receive(:cause).and_return(OpenStruct.new(http_code: 404))
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer).and_raise(error)
+      expect(ChargeBee::HostedPage).to receive(:checkout_new).and_return(result)
+      expect(described_class.new_subscription_hosted_page(1, 'personal_lite')).to eq({ id: 'hp_1' })
+    end
+
+    it 'uses checkout_existing with reactivate for a cancelled subscription' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer)
+        .and_return([entry('cancelled', 'personal_lite', 'sub_1')])
+      expect(ChargeBee::HostedPage).to receive(:checkout_existing)
+        .with(hash_including(reactivate: true, subscription: hash_including(id: 'sub_1', plan_id: 'personal_lite')))
+        .and_return(result)
+      expect(described_class.new_subscription_hosted_page(1, 'personal_lite')).to eq({ id: 'hp_1' })
+    end
+
+    it 'uses checkout_existing without reactivate for a live subscription' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer)
+        .and_return([entry('active', 'personal_lite', 'sub_1')])
+      expect(ChargeBee::HostedPage).to receive(:checkout_existing)
+        .with(hash_including(reactivate: false))
+        .and_return(result)
+      described_class.new_subscription_hosted_page(1, 'personal_premium')
+    end
+  end
+
+  describe '.subscription' do
+    it 'returns the plan of the first live subscription' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer)
+        .and_return([entry('cancelled', 'personal_premium'), entry('active', 'personal_lite')])
+      expect(described_class.subscription(1)).to eq 'personal_lite'
+    end
+
+    it 'counts a non_renewing subscription as live' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer)
+        .and_return([entry('non_renewing', 'personal_lite')])
+      expect(described_class.subscription(1)).to eq 'personal_lite'
+    end
+
+    it 'returns nil when all subscriptions are cancelled' do
+      allow(ChargeBee::Subscription).to receive(:subscriptions_for_customer)
+        .and_return([entry('cancelled', 'personal_lite')])
+      expect(described_class.subscription(1)).to be_nil
+    end
+  end
+end

--- a/spec/models/user_account_spec.rb
+++ b/spec/models/user_account_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe UserAccount, type: :model do
+  let(:user) { FactoryBot.create(:user, plan: :personal_lite) }
+  let(:account) { user.account }
+
+  describe '#new_subscription_iframe' do
+    it 'is blocked for users on a live paid plan' do
+      account.update_attribute(:has_payment_account, true)
+      expect(account.new_subscription_iframe('personal_lite')).to eq false
+    end
+
+    it 'is allowed for free users with a payment account (cancelled subscription)' do
+      user.update_attribute(:plan, 'personal_free')
+      account.update_attribute(:has_payment_account, true)
+      expect(account.new_subscription_iframe('personal_lite')).to be_a ExternalSubscriptions::NewSubscriptionIframe
+    end
+
+    it 'is allowed for users without a payment account' do
+      expect(account.new_subscription_iframe('personal_lite')).to be_a ExternalSubscriptions::NewSubscriptionIframe
+    end
+  end
+
+  describe '#synchronize!' do
+    before do
+      allow(ExternalSubscriptions::Adapter).to receive(:has_account).and_return(true)
+    end
+
+    it 'sets the plan from the live external subscription' do
+      allow(ExternalSubscriptions::Adapter).to receive(:subscription).and_return('personal_premium')
+      account.synchronize!
+      expect(user.reload.plan).to eq 'personal_premium'
+    end
+
+    it 'downgrades to free when there is no live subscription' do
+      allow(ExternalSubscriptions::Adapter).to receive(:subscription).and_return(nil)
+      account.synchronize!
+      expect(user.reload.plan).to eq 'personal_free'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,18 @@ class AdapterMock
   class << self
     def create_subscription(entity_id, plan_id)
     end
+
+    def has_account(entity_id)
+      false
+    end
+
+    def subscription(entity_id)
+      nil
+    end
+
+    def new_subscription_hosted_page(entity_id, plan_id)
+      { id: 'hp_fake', url: 'http://fake.test' }
+    end
   end
 end
 class PaymentPortalMock


### PR DESCRIPTION
Makes billing sync robust and fixes the broken flows found in dev/prod testing:

- **Webhooks**: `POST /chargebee/webhooks` (HTTP basic auth) re-syncs the named user from the Chargebee API on any event, so subscribe/cancel/renewal no longer depend on the browser firing a callback. After deploy, set `CHARGEBEE_WEBHOOK_USERNAME`/`CHARGEBEE_WEBHOOK_PASSWORD` in prod and register the webhook in Chargebee.
- **Cancel sync**: `Adapter.subscription` only counts live subscriptions (future/in_trial/active/non_renewing); sync downgrades to `personal_free` when the subscription is cancelled.
- **Re-subscribe**: customers who already have a subscription get a `checkout_existing` hosted page (with `reactivate` for cancelled subs) — fixes the 500 ("customer already has a subscription") and the pay-but-stay-cancelled bug.
- Free users with a payment account may subscribe again.

Tested in dev against the live Chargebee test site (cancel→free sync, reactivation checkout, webhook auth); rspec 263 green.

Companion frontend PR: getguesstimate/guesstimate-app#1063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)